### PR TITLE
feat: add local likes and self-delete on live wall

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tiny, static microsite to collect birthday wishes and favorite memories and di
 
 ## What’s here
 - `index.html`: Simple form to submit a wish (max 800 chars), name, and consent. Persists the name in `localStorage`. Shows a confetti animation on success.
-- `livewall.html`: Auto‑refreshing grid that fetches consented notes every 4 seconds and renders them for display (e.g., on a projector). Escapes HTML to prevent XSS.
+- `livewall.html`: Auto‑refreshing grid that fetches consented notes every 4 seconds and renders them for display (e.g., on a projector). Each note includes a local ❤️ like counter and a 🗑️ delete button. Delete buttons appear for notes submitted from the same browser or, if you open the page with ?admin=1, for every note. Deleted notes stay hidden after you refresh. Escapes HTML to prevent XSS.
 
 Both files POST/GET to the same `ENDPOINT_URL` (a Google Apps Script Web App).
 
@@ -75,4 +75,5 @@ After deploying, copy the Web App URL and set it as `ENDPOINT_URL` in both HTML 
 - Privacy: Only messages with `consent` render on the wall; storage is in your Google Sheet.
 - Safety: The wall escapes HTML before rendering; keep doing server‑side validation in Apps Script as needed.
 - Customization: Update colors, copy, and limits inline in the two HTML files.
+- Likes and deletes are stored in the viewer's browser and don't affect the underlying data. Deleted notes are hidden only locally. Open livewall.html?admin=1 to enable delete controls for all notes.
 

--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
         const data = await res.json();
         if(data.ok){
           localStorage.setItem('nidhi40_name', who);
+          saveOwn(who, text);
           msg.value=''; consent.checked=false; counter.textContent='0 / 800';
           show("success"); confetti();
         } else { show("error"); }
@@ -109,6 +110,19 @@
 
     function show(id){ $(id).style.display='block'; }
     function hide(id){ $(id).style.display='none'; }
+
+    function makeKey(name,msg){
+      return btoa(unescape(encodeURIComponent(name.trim()+"|"+msg.trim())));
+    }
+
+    function saveOwn(name,msg){
+      const key = makeKey(name,msg);
+      const list = JSON.parse(localStorage.getItem('nidhi40_own')||'[]');
+      if(!list.includes(key)){
+        list.push(key);
+        localStorage.setItem('nidhi40_own', JSON.stringify(list));
+      }
+    }
 
     function confetti(){
       const N = 120; const dur=1200; const body=document.body; const rect = body.getBoundingClientRect();

--- a/livewall.html
+++ b/livewall.html
@@ -17,6 +17,9 @@
     .name{font-weight:700;color:#c9006c;margin-bottom:8px}
     .msg{font-size:16px;line-height:1.35;}
     .muted{color:#666}
+    .actions{margin-top:10px;display:flex;gap:10px}
+    .like-btn,.del-btn{background:none;border:none;cursor:pointer;color:#c9006c;font-size:14px;display:flex;align-items:center;gap:4px;padding:4px 6px;border-radius:8px}
+    .like-btn:hover,.del-btn:hover{background:#ffe7f4}
   </style>
 </head>
 <body>
@@ -30,6 +33,11 @@
     const grid = document.getElementById('grid');
     const dot  = document.getElementById('dot');
     let lastCount = 0;
+    const own = new Set(JSON.parse(localStorage.getItem('nidhi40_own')||'[]'));
+    const params = new URLSearchParams(location.search);
+    if(params.get('admin')==='1') localStorage.setItem('nidhi40_admin','1');
+    if(params.get('admin')==='0') localStorage.removeItem('nidhi40_admin');
+    const isAdmin = localStorage.getItem('nidhi40_admin')==='1';
 
     async function load(){
       try{
@@ -37,10 +45,12 @@
         const data = await res.json();
         if(!data.ok) throw new Error('not ok');
         dot.classList.add('ok');
-        const items = data.items.filter(x=>x.consent);
-        if(items.length!==lastCount){
-          grid.innerHTML = items.slice(-120).map(render).join('');
-          lastCount = items.length;
+        const allItems = data.items.filter(x=>x.consent);
+        if(allItems.length!==lastCount){
+          const hidden = new Set(JSON.parse(localStorage.getItem('nidhi40_hidden')||'[]'));
+            const display = allItems.filter(it=>!hidden.has(getId(it)));
+          grid.innerHTML = display.slice(-120).map(render).join('');
+          lastCount = allItems.length;
         }
       }catch(e){ dot.classList.remove('ok'); }
     }
@@ -48,12 +58,43 @@
     function render(it){
       const name = escapeHtml(it.name||'');
       const msg  = escapeHtml(it.message||'');
-      return `<article class="card"><div class="name">${name}</div><div class="msg">${msg}</div></article>`;
+        const id   = getId(it);
+        const likes = Number(localStorage.getItem('nidhi40_like_'+id)||0);
+        const key = makeKey(it.name||'', it.message||'');
+        const del = (isAdmin || own.has(key)) ? '<button class="del-btn">🗑️</button>' : '';
+        return `<article class="card" data-id="${id}"><div class="name">${name}</div><div class="msg">${msg}</div><div class="actions"><button class="like-btn">❤️ <span class="count">${likes}</span></button>${del}</div></article>`;
     }
 
     function escapeHtml(s){
       return (s||'').replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
     }
+
+      function makeKey(name,msg){
+        return btoa(unescape(encodeURIComponent(name.trim()+"|"+msg.trim())));
+      }
+
+      function getId(it){
+        return String(it.ts || makeKey(it.name||'', it.message||''));
+      }
+    grid.addEventListener('click', e=>{
+      const card = e.target.closest('.card');
+      if(!card) return;
+      const id = card.dataset.id;
+      if(e.target.closest('.like-btn')){
+        const key = 'nidhi40_like_'+id;
+        let c = Number(localStorage.getItem(key)||0)+1;
+        localStorage.setItem(key,c);
+        card.querySelector('.count').textContent = c;
+      } else if(e.target.closest('.del-btn')){
+        card.remove();
+        const key = 'nidhi40_hidden';
+        const hidden = JSON.parse(localStorage.getItem(key)||'[]');
+        if(!hidden.includes(id)){
+          hidden.push(id);
+          localStorage.setItem(key, JSON.stringify(hidden));
+        }
+      }
+    });
 
     load(); setInterval(load, 4000);
   </script>


### PR DESCRIPTION
## Summary
- resolve merge conflicts with main for README and livewall
- support per-browser likes and delete controls on the live wall with admin override
- document local-only likes and deletes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b35281cee0832ca25860a5089b080f