### PR TITLE
feat: add private live wall with local like/delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
-# Nidhi @ 40 — Wishes & Live Wall
+# Nidhi @ 40 — Wishes
 
-A tiny, static microsite to collect birthday wishes and favorite memories and display them on a live wall. No build step, no dependencies — just HTML/CSS/JS plus a Google Apps Script backend.
+A tiny, static microsite to collect birthday wishes and favorite memories. No build step, no dependencies — just HTML/CSS/JS plus a Google Apps Script backend.
 
 ## What’s here
 - `index.html`: Simple form to submit a wish (max 800 chars), name, and consent. Persists the name in `localStorage`. Shows a confetti animation on success.
-- `livewall.html`: Auto‑refreshing grid that fetches consented notes every 4 seconds and renders them for display (e.g., on a projector). Escapes HTML to prevent XSS.
+- `livewall.html`: Auto‑refreshing wall of wishes with local like/delete controls. It isn’t linked from the form—open `/livewall` (or `/livewall.html`) directly if you have the URL.
 
-Both files POST/GET to the same `ENDPOINT_URL` (a Google Apps Script Web App).
+The form posts to the `ENDPOINT_URL` (a Google Apps Script Web App).
 
 ## Quick start
 - Open `index.html` locally to submit a test message.
-- Open `livewall.html` to see the live wall update.
 
-Tip: If you fork or reuse this, update the `ENDPOINT_URL` in both files.
+Tip: If you fork or reuse this, update the `ENDPOINT_URL` in `index.html`.
 
 ## Backend (Google Apps Script)
 The site expects a Web App endpoint that:
@@ -63,16 +62,17 @@ function json(obj) {
 }
 ```
 
-After deploying, copy the Web App URL and set it as `ENDPOINT_URL` in both HTML files.
+After deploying, copy the Web App URL and set it as `ENDPOINT_URL` in `index.html`.
 
 ## Deploy (GitHub Pages)
 - Push this repo to GitHub (done).
 - In the repo Settings → Pages, set Source to `main` (root).
 - Your site will be available at `https://<your-username>.github.io/<repo>/`.
-- Open `index.html` to submit and `livewall.html` to display.
+- Open `index.html` to submit.
 
 ## Notes
-- Privacy: Only messages with `consent` render on the wall; storage is in your Google Sheet.
-- Safety: The wall escapes HTML before rendering; keep doing server‑side validation in Apps Script as needed.
-- Customization: Update colors, copy, and limits inline in the two HTML files.
+- Privacy: submissions are stored in your Google Sheet.
+- Safety: keep doing server‑side validation in Apps Script as needed.
+- Customization: update colors, copy, and limits inline in the HTML file.
+- Live wall actions (likes/deletes) are stored locally per browser.
 

--- a/index.html
+++ b/index.html
@@ -58,7 +58,6 @@
 
     <div style="margin-top:16px" class="row">
       <button id="submit">Send Wish ✨</button>
-      <a class="link tiny" href="./livewall.html" target="_blank">Open Live Wall</a>
     </div>
 
     <div id="success" class="success">Thanks! Your note was received. 🎉 You can close this or submit another from the same phone.</div>

--- a/livewall.html
+++ b/livewall.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Nidhi @ 40 — Live Love Notes Wall</title>
+  <title>Nidhi @ 40 — Live Wishes</title>
   <style>
     :root{--pink:#ff2ea6;--ink:#101010;}
     *{box-sizing:border-box}
@@ -15,8 +15,10 @@
     .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:16px;padding:18px}
     .card{border:2px solid #ffd2ea;border-radius:18px;padding:16px;background:#fff;box-shadow:0 6px 16px rgba(255,46,166,.12)}
     .name{font-weight:700;color:#c9006c;margin-bottom:8px}
-    .msg{font-size:16px;line-height:1.35;}
-    .muted{color:#666}
+    .msg{font-size:16px;line-height:1.35}
+    footer{display:flex;gap:12px;margin-top:10px}
+    button{cursor:pointer;border:none;border-radius:8px;padding:6px 10px;font-size:14px;background:#ffd2ea;color:#c9006c}
+    button:hover{background:#ffb5de}
   </style>
 </head>
 <body>
@@ -30,6 +32,8 @@
     const grid = document.getElementById('grid');
     const dot  = document.getElementById('dot');
     let lastCount = 0;
+    const deleted = JSON.parse(localStorage.getItem('nidhi40_deleted')||'[]');
+    const likes   = JSON.parse(localStorage.getItem('nidhi40_likes')||'{}');
 
     async function load(){
       try{
@@ -37,7 +41,7 @@
         const data = await res.json();
         if(!data.ok) throw new Error('not ok');
         dot.classList.add('ok');
-        const items = data.items.filter(x=>x.consent);
+        const items = data.items.filter(x=>x.consent).map(it=>({...it,id:idFor(it)})).filter(it=>!deleted.includes(it.id));
         if(items.length!==lastCount){
           grid.innerHTML = items.slice(-120).map(render).join('');
           lastCount = items.length;
@@ -48,14 +52,37 @@
     function render(it){
       const name = escapeHtml(it.name||'');
       const msg  = escapeHtml(it.message||'');
-      return `<article class="card"><div class="name">${name}</div><div class="msg">${msg}</div></article>`;
+      const likeCount = likes[it.id]||0;
+      return `<article class="card" data-id="${it.id}"><div class="name">${name}</div><div class="msg">${msg}</div><footer><button class="like">❤️ <span>${likeCount}</span></button><button class="del">🗑️</button></footer></article>`;
+    }
+
+    grid.addEventListener('click', ev=>{
+      const card = ev.target.closest('.card');
+      if(!card) return;
+      const id = card.getAttribute('data-id');
+      if(ev.target.closest('.like')){
+        likes[id] = (likes[id]||0)+1;
+        localStorage.setItem('nidhi40_likes', JSON.stringify(likes));
+        ev.target.closest('.like').querySelector('span').textContent = likes[id];
+      } else if(ev.target.closest('.del')){
+        deleted.push(id);
+        localStorage.setItem('nidhi40_deleted', JSON.stringify(deleted));
+        card.remove();
+      }
+    });
+
+    function idFor(it){
+      const str = (it.name||'')+'|'+(it.message||'');
+      let h=0;
+      for(let i=0;i<str.length;i++) h = (Math.imul(31,h) + str.charCodeAt(i)) | 0;
+      return h.toString(16);
     }
 
     function escapeHtml(s){
-      return (s||'').replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
+      return (s||'').replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
     }
 
-    load(); setInterval(load, 4000);
+    load(); setInterval(load,4000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `livewall.html` page showing wishes with local like/delete buttons
- document direct `/livewall` access and local-only actions in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b35281cee0832ca25860a5089b080f